### PR TITLE
Fix arrays writing with PyTelTools and other improvments

### DIFF
--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -41,7 +41,7 @@ def test_to_selafin(tmp_path, slf_in):
     ds_slf = xr.open_dataset(slf_in, engine="selafin")
     slf_out = tmp_path / "test.slf"
     ds_slf.selafin.write(slf_out)
-    ds_slf2 = xr.open_dataset(slf_out)
+    ds_slf2 = xr.open_dataset(slf_out, engine="selafin")
     assert ds_slf2.equals(ds_slf)
 
 


### PR DESCRIPTION
I am not able to run tests and `dataset.equals` does not seem to work on my environment (it raises a `numpy.exceptions.AxisError`).

But what has been tested so far:
- test_open_dataset: OK
- test_to_selafin: OK (same binary input/output file)
- test_to_slice: OK only for time selection

